### PR TITLE
feat(idle): filtering the reallocation that are supplying into the idle market

### DIFF
--- a/src/components/OutOfBoundsMarketBubble.tsx
+++ b/src/components/OutOfBoundsMarketBubble.tsx
@@ -98,7 +98,12 @@ const OutOfBoundsMarketBubble: React.FC<OutOfBoundsMarketBubbleProps> = ({
     setButtonVisible(false);
     try {
       const fetchedVaults = await lookForReallocations(networkId, market);
-      setVaults(fetchedVaults);
+      const filteredVaults = fetchedVaults.filter(
+        (vault) =>
+          !vault.reallocation ||
+          vault.reallocation.supplyMarketParams.collateralToken
+      );
+      setVaults(filteredVaults);
       setReallocationsSearched(true);
     } catch (err) {
       setError("Failed to fetch reallocations");

--- a/src/components/VaultFlowCapsBubble.tsx
+++ b/src/components/VaultFlowCapsBubble.tsx
@@ -46,8 +46,6 @@ const VaultFlowCapsBubble: React.FC<VaultFlowCapsBubbleProps> = ({
 
   const missingFlowCaps = vault.warnings.missingFlowCaps ?? false;
 
-  console.log("missingFlowCaps", missingFlowCaps);
-
   return (
     <StyledBubble
       expanded={expanded}

--- a/src/components/VaultReallocationDataBubble.tsx
+++ b/src/components/VaultReallocationDataBubble.tsx
@@ -15,13 +15,19 @@ const MarketContainer = styled.div`
 type VaultBubbleProps = {
   vault: VaultReallocationData;
   networkId: number;
+  filterIdleMarkets: boolean;
 };
 
 const VaultReallocationDataBubble: React.FC<VaultBubbleProps> = ({
   vault,
   networkId,
+  filterIdleMarkets,
 }) => {
   const [expanded, setExpanded] = useState(false);
+
+  const shouldDisplayReallocation =
+    !filterIdleMarkets ||
+    vault.reallocation?.supplyMarketParams.collateralToken !== undefined;
 
   const backgroundColor = vault.reallocation ? "#2470ff" : "#4B0082";
 
@@ -29,6 +35,10 @@ const VaultReallocationDataBubble: React.FC<VaultBubbleProps> = ({
     event.stopPropagation();
     setExpanded(!expanded);
   };
+
+  if (filterIdleMarkets && !shouldDisplayReallocation) {
+    return null;
+  }
 
   return (
     <div>

--- a/src/core/lookForReallocations.ts
+++ b/src/core/lookForReallocations.ts
@@ -29,7 +29,8 @@ import {
 
 export const lookForReallocations = async (
   networkId: number,
-  outOfBoundsMarket: OutOfBoundsMarket
+  outOfBoundsMarket: OutOfBoundsMarket,
+  filterIdleMarkets: boolean
 ) => {
   const provider = MulticallWrapper.wrap(getProvider(networkId));
 
@@ -62,8 +63,16 @@ export const lookForReallocations = async (
           networkId
         ),
         reallocation: outOfBoundsMarket.aboveRange
-          ? seekForSupplyReallocation(outOfBoundsMarket.id, vault)
-          : seekForWithdrawReallocation(outOfBoundsMarket.id, vault),
+          ? seekForSupplyReallocation(
+              outOfBoundsMarket.id,
+              vault,
+              filterIdleMarkets
+            )
+          : seekForWithdrawReallocation(
+              outOfBoundsMarket.id,
+              vault,
+              filterIdleMarkets
+            ),
       };
     }
   );

--- a/src/core/marketsWithoutStrategy.ts
+++ b/src/core/marketsWithoutStrategy.ts
@@ -8,8 +8,6 @@ import { formatMarketLink, getMarketName } from "../utils/utils";
 export const getMarketsWithoutStrategy = async (
   networkId: number
 ): Promise<MarketWithoutStrategy[]> => {
-  console.log("fetching strategies");
-
   const strategies = await fetchStrategies(networkId);
 
   const marketWithoutStrategies = strategies.filter(
@@ -21,8 +19,6 @@ export const getMarketsWithoutStrategy = async (
       (strategy.utilizationTarget !== undefined &&
         BigInt(strategy.utilizationTarget) === 0n)
   );
-
-  console.log("fetching market data");
 
   const marketData = await Promise.all(
     marketWithoutStrategies.map(async (strategy) =>

--- a/src/core/outOfBoundsMarkets.ts
+++ b/src/core/outOfBoundsMarkets.ts
@@ -23,11 +23,7 @@ export const getOutOfBoundsMarkets = async (
 ): Promise<OutOfBoundsMarket[]> => {
   const provider = MulticallWrapper.wrap(getProvider(networkId));
 
-  console.log("fetching strategies");
-
   const strategies = await fetchStrategies(networkId);
-
-  console.log("fetching market data");
 
   const whitelistedMarkets = await Promise.all(
     strategies.map(async (strategy) => {
@@ -161,8 +157,6 @@ export const getOutOfBoundsMarkets = async (
       });
     }
   }
-
-  console.log("sorting markets");
 
   return outOfBoundsMarkets.sort(
     (a, b) =>

--- a/src/core/vaultData.ts
+++ b/src/core/vaultData.ts
@@ -22,27 +22,19 @@ import { MulticallWrapper } from "ethers-multicall-provider";
 export const getVaultDisplayData = async (
   networkId: number
 ): Promise<VaultData[]> => {
-  console.log("fetching strategies");
-
   const strategies = await fetchStrategies(networkId);
 
   const provider = MulticallWrapper.wrap(getProvider(networkId));
 
-  console.log("fetching whitelisted vaults");
-
   const whitelistedVaults = (
     await fetchWhitelistedMetaMorphos(networkId)
   ).filter((vault) => !vaultBlacklist[networkId]!.includes(vault.address));
-
-  console.log("fetching vaults data");
 
   const vaults = await Promise.all(
     whitelistedVaults.map((vault) =>
       fetchVaultData(vault.address, networkId, strategies, provider)
     )
   );
-
-  console.log("vault data fetched");
 
   const missingFlowCaps = [];
 
@@ -114,8 +106,6 @@ export const getVaultDisplayData = async (
       warnings,
     });
   }
-
-  console.log("everithing fetched");
 
   return sortVaults(missingFlowCaps);
 };

--- a/src/fetchers/apiFetchers.ts
+++ b/src/fetchers/apiFetchers.ts
@@ -371,23 +371,17 @@ export const fetchMarketsWithWarnings = async (
     (market: MarketWithWarningAPIData) => market.warnings.length > 0
   );
 
-  console.log("markets with warnings");
-
   const marketWithRedWarnings = marketsWithWarnings
     .filter((market) =>
       market.warnings!.some((warning) => warning.level === "RED")
     )
     .map((market) => formatMarketWithWarning(market, networkId));
 
-  console.log("markets with red warnings");
-
   const marketWithoutRedWarnings = marketsWithWarnings
     .filter(
       (market) => !market.warnings!.some((warning) => warning.level === "RED")
     )
     .map((market) => formatMarketWithWarning(market, networkId));
-
-  console.log("markets returned");
 
   return [...marketWithRedWarnings, ...marketWithoutRedWarnings];
 };

--- a/src/utils/reallocationMaths.ts
+++ b/src/utils/reallocationMaths.ts
@@ -119,17 +119,6 @@ export const seekForSupplyReallocation = (
   vault: MetaMorphoVault,
   filterIdleMarkets: boolean
 ): Reallocation | undefined => {
-  if (
-    filterIdleMarkets &&
-    vault.positions[marketToSupplyIntoId].marketData.collateralAsset.address ===
-      "0x0000000000000000000000000000000000000000"
-  ) {
-    console.log(
-      "collateral asset is undefined, this corresponds to an idle market we don't want to reallocate in it"
-    );
-    return undefined;
-  }
-
   const marketToSupplyInto = vault.positions[marketToSupplyIntoId].marketData;
 
   const toSupply = computeToSupplyReallocate(
@@ -138,7 +127,13 @@ export const seekForSupplyReallocation = (
     MaxUint256
   ).toSupply;
 
-  const enabledMarketIds = Object.keys(vault.positions);
+  const enabledMarketIds = Object.keys(vault.positions).filter(
+    (marketId) =>
+      !filterIdleMarkets ||
+      vault.positions[marketId].marketData.collateralAsset.address !==
+        "0x0000000000000000000000000000000000000000"
+  );
+
   const totalToWithdraw = enabledMarketIds.reduce(
     (total, enabledMarketId) =>
       total +


### PR DESCRIPTION
The logic remains the same: we keep vaults that either have no reallocation (!vault.reallocation) or have a reallocation with a collateral token (vault.reallocation.supplyMarketParams.collateralToken).